### PR TITLE
Added fall-through for platforms

### DIFF
--- a/Assets/Prefabs/MSCharacter.prefab
+++ b/Assets/Prefabs/MSCharacter.prefab
@@ -202,6 +202,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4248694440051614380}
+  - component: {fileID: 4814266332498745331}
+  - component: {fileID: 3567880775235254931}
   m_Layer: 8
   m_Name: GroundCheck
   m_TagString: Untagged
@@ -223,6 +225,44 @@ Transform:
   m_Father: {fileID: 4443951294556298768}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4814266332498745331
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3599254458222394571}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9c6939a0e6984063bf787bbc0b5da84, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!61 &3567880775235254931
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3599254458222394571}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1.692308}
+  m_EdgeRadius: 0
 --- !u!1 &4443951294556298772
 GameObject:
   m_ObjectHideFlags: 0
@@ -489,13 +529,13 @@ MonoBehaviour:
   ropeSystem: {fileID: 4443951294556298769}
   crosshair: {fileID: 8099013692215979369}
   animator: {fileID: 6885775752252314838}
-  match: {fileID: 0}
   alive: 1
   melee: {fileID: 2907988911900256694}
   sprite: {fileID: 4443951294556298773}
   machine: {fileID: -2980204640073275049}
   leftWallCheck: {fileID: 7708910355634086536}
   rightWallCheck: {fileID: 2726607943822493693}
+  groundCheck: {fileID: 4814266332498745331}
   moveX: 0
   rBody: {fileID: 4443951294556298770}
   numArrows: 5

--- a/Assets/Scripts/GroundCheck.cs
+++ b/Assets/Scripts/GroundCheck.cs
@@ -1,0 +1,33 @@
+﻿using UnityEngine;
+using System.Collections;
+
+public class GroundCheck : MonoBehaviour {
+    // Layer of the ground the player is on; -1 if not on the ground
+    private int TouchingLayer { get; set; }
+    private int noLayer, wallLayer, platformLayer;
+
+    void Awake() {
+        TouchingLayer = -1;
+        noLayer = -1;
+        wallLayer = LayerMask.NameToLayer("Wall");
+        platformLayer = LayerMask.NameToLayer("Platform");
+    }
+
+    void OnTriggerEnter2D(Collider2D collision) {
+        int layer = collision.gameObject.layer;
+        if (layer == wallLayer || layer == platformLayer) {
+            TouchingLayer = layer;
+        }
+    }
+
+    void OnTriggerExit2D(Collider2D collision) {
+        int layer = collision.gameObject.layer;
+        if (layer == wallLayer || layer == platformLayer) {
+            TouchingLayer = noLayer;
+        }
+    }
+
+    public bool isTouchingPlatform() {
+        return TouchingLayer == platformLayer;
+    }
+}

--- a/Assets/Scripts/GroundCheck.cs.meta
+++ b/Assets/Scripts/GroundCheck.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9c6939a0e6984063bf787bbc0b5da84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/InputActionMapper.cs
+++ b/Assets/Scripts/InputActionMapper.cs
@@ -53,7 +53,7 @@ public class InputActionMapper: MonoBehaviour {
         get { return arrowShoot.ReadValue<float>() > 0.5f; }
     }
 
-    public bool FallPressed {
+    public bool DownPressed {
         get
         {
             var direction = move.ReadValue<Vector2>();

--- a/Assets/Scripts/InputActionMapper.cs
+++ b/Assets/Scripts/InputActionMapper.cs
@@ -53,7 +53,7 @@ public class InputActionMapper: MonoBehaviour {
         get { return arrowShoot.ReadValue<float>() > 0.5f; }
     }
 
-    public bool HookReleasePressed {
+    public bool FallPressed {
         get
         {
             var direction = move.ReadValue<Vector2>();

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -126,8 +126,8 @@ public class PlayerController : MonoBehaviour {
         if (actions.JumpPressed) {
             return JUMP_STATE;
         }
-        // fall through platforms
-        if (actions.FallPressed && groundCheck.isTouchingPlatform()) {
+        // fall through platformsF
+        if (actions.DownPressed && groundCheck.isTouchingPlatform()) {
             return FALL_THROUGH_PLATFORM_STATE;
         }
         // falling
@@ -153,7 +153,7 @@ public class PlayerController : MonoBehaviour {
             return JUMP_STATE;
         }
         // fall through platforms
-        if (actions.FallPressed && groundCheck.isTouchingPlatform()) {
+        if (actions.DownPressed && groundCheck.isTouchingPlatform()) {
             return FALL_THROUGH_PLATFORM_STATE;
         }
         // falling
@@ -217,7 +217,7 @@ public class PlayerController : MonoBehaviour {
     }
 
     private int HookPullUpdate() {
-        if (actions.FallPressed) {
+        if (actions.DownPressed) {
             ropeSystem.ResetRope();
             return FALL_STATE;
         }
@@ -238,7 +238,7 @@ public class PlayerController : MonoBehaviour {
     }
 
     private int HookEndUpdate() {
-        if (actions.FallPressed || actions.HorizontalDirection != 0) {
+        if (actions.DownPressed || actions.HorizontalDirection != 0) {
             ropeSystem.ResetRope();
             return FALL_STATE;
         }


### PR DESCRIPTION
Allows falling through platforms using the same action hook-release would have used. Mechanism for falling through slightly sketchy (manually updating rbody position) since collider-layer ignoring is not currently implemented (https://forum.unity.com/threads/ignore-between-a-collider-and-a-layer.459537/) so we have to do this, unless we want to rewrite physics