### PR TITLE
added support for gamepad focusing

### DIFF
--- a/Assets/Input/Goose Game.inputactions
+++ b/Assets/Input/Goose Game.inputactions
@@ -597,7 +597,7 @@
                     "path": "*/{Submit}",
                     "interactions": "",
                     "processors": "",
-                    "groups": "Keyboard&Mouse",
+                    "groups": "",
                     "action": "Submit",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -744,6 +744,61 @@
                     "action": "TrackedDeviceSelect",
                     "isComposite": false,
                     "isPartOfComposite": false
+                },
+                {
+                    "name": "Arrows",
+                    "id": "d050f0c3-7d03-44f6-b875-465daff8a81e",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "b5a84c5a-74e2-45f4-b36f-c56f40405045",
+                    "path": "<Keyboard>/upArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "8c799e66-d653-4a05-a8de-3b63d75a5c75",
+                    "path": "<Keyboard>/downArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "dd2a295b-7347-432b-9712-b7fb894754e3",
+                    "path": "<Keyboard>/leftArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "579578ae-3a71-4c13-871a-2c9d1c704754",
+                    "path": "<Keyboard>/rightArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
                 }
             ]
         }

--- a/Assets/Prefabs/GameLobbyPlayer.prefab
+++ b/Assets/Prefabs/GameLobbyPlayer.prefab
@@ -10,7 +10,8 @@ GameObject:
   m_Component:
   - component: {fileID: 2854233066694896765}
   - component: {fileID: 7605518071071815002}
-  - component: {fileID: 4904866065223827252}
+  - component: {fileID: 2035027779737674478}
+  - component: {fileID: 5205966020759154696}
   m_Layer: 0
   m_Name: GameLobbyPlayer
   m_TagString: Untagged
@@ -52,7 +53,7 @@ MonoBehaviour:
   m_Actions: {fileID: -944628639613478452, guid: d80d7c671c79a4663a165a0a38e5cb17,
     type: 3}
   m_NotificationBehavior: 0
-  m_UIInputModule: {fileID: 0}
+  m_UIInputModule: {fileID: 5205966020759154696}
   m_DeviceLostEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -216,55 +217,60 @@ MonoBehaviour:
     m_ActionName: UI/TrackedDeviceSelect
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: Keyboard&Mouse
-  m_DefaultActionMap: Player
+  m_DefaultActionMap: UI
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
---- !u!212 &4904866065223827252
-SpriteRenderer:
+--- !u!114 &2035027779737674478
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4485563698593125436}
   m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: -979931886528107223, guid: 78744a2bd9aeb460a825c0bbd827c474,
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b16c6f78230fa4964a222622d8aae332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+  m_PlayerRoot: {fileID: 0}
+--- !u!114 &5205966020759154696
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4485563698593125436}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RepeatDelay: 0.5
+  m_RepeatRate: 0.1
+  m_ActionsAsset: {fileID: -944628639613478452, guid: d80d7c671c79a4663a165a0a38e5cb17,
     type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
+  m_PointAction: {fileID: 1054132383583890850, guid: d80d7c671c79a4663a165a0a38e5cb17,
+    type: 3}
+  m_MoveAction: {fileID: 3710738434707379630, guid: d80d7c671c79a4663a165a0a38e5cb17,
+    type: 3}
+  m_SubmitAction: {fileID: 2064916234097673511, guid: d80d7c671c79a4663a165a0a38e5cb17,
+    type: 3}
+  m_CancelAction: {fileID: -1967631576421560919, guid: d80d7c671c79a4663a165a0a38e5cb17,
+    type: 3}
+  m_LeftClickAction: {fileID: 8056856818456041789, guid: d80d7c671c79a4663a165a0a38e5cb17,
+    type: 3}
+  m_MiddleClickAction: {fileID: 3279352641294131588, guid: d80d7c671c79a4663a165a0a38e5cb17,
+    type: 3}
+  m_RightClickAction: {fileID: 3837173908680883260, guid: d80d7c671c79a4663a165a0a38e5cb17,
+    type: 3}
+  m_ScrollWheelAction: {fileID: 4502412055082496612, guid: d80d7c671c79a4663a165a0a38e5cb17,
+    type: 3}
+  m_TrackedDevicePositionAction: {fileID: 4754684134866288074, guid: d80d7c671c79a4663a165a0a38e5cb17,
+    type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 1025543830046995696, guid: d80d7c671c79a4663a165a0a38e5cb17,
+    type: 3}
+  m_TrackedDeviceSelectAction: {fileID: 2559092417903258184, guid: d80d7c671c79a4663a165a0a38e5cb17,
+    type: 3}

--- a/Assets/Scenes/EndGame.unity
+++ b/Assets/Scenes/EndGame.unity
@@ -420,7 +420,7 @@ MonoBehaviour:
   m_Script: {fileID: -619905303, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
+  m_FirstSelected: {fileID: 1562107956}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
 --- !u!4 &130452169

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -1066,29 +1066,29 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_RepeatDelay: 0.5
   m_RepeatRate: 0.1
-  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018,
+  m_ActionsAsset: {fileID: -944628639613478452, guid: d80d7c671c79a4663a165a0a38e5cb17,
     type: 3}
-  m_PointAction: {fileID: 1054132383583890850, guid: ca9f5fa95ffab41fb9a615ab714db018,
+  m_PointAction: {fileID: 1054132383583890850, guid: d80d7c671c79a4663a165a0a38e5cb17,
     type: 3}
-  m_MoveAction: {fileID: 3710738434707379630, guid: ca9f5fa95ffab41fb9a615ab714db018,
+  m_MoveAction: {fileID: 3710738434707379630, guid: d80d7c671c79a4663a165a0a38e5cb17,
     type: 3}
-  m_SubmitAction: {fileID: 2064916234097673511, guid: ca9f5fa95ffab41fb9a615ab714db018,
+  m_SubmitAction: {fileID: 2064916234097673511, guid: d80d7c671c79a4663a165a0a38e5cb17,
     type: 3}
-  m_CancelAction: {fileID: -1967631576421560919, guid: ca9f5fa95ffab41fb9a615ab714db018,
+  m_CancelAction: {fileID: -1967631576421560919, guid: d80d7c671c79a4663a165a0a38e5cb17,
     type: 3}
-  m_LeftClickAction: {fileID: 8056856818456041789, guid: ca9f5fa95ffab41fb9a615ab714db018,
+  m_LeftClickAction: {fileID: 8056856818456041789, guid: d80d7c671c79a4663a165a0a38e5cb17,
     type: 3}
-  m_MiddleClickAction: {fileID: 3279352641294131588, guid: ca9f5fa95ffab41fb9a615ab714db018,
+  m_MiddleClickAction: {fileID: 3279352641294131588, guid: d80d7c671c79a4663a165a0a38e5cb17,
     type: 3}
-  m_RightClickAction: {fileID: 3837173908680883260, guid: ca9f5fa95ffab41fb9a615ab714db018,
+  m_RightClickAction: {fileID: 3837173908680883260, guid: d80d7c671c79a4663a165a0a38e5cb17,
     type: 3}
-  m_ScrollWheelAction: {fileID: 4502412055082496612, guid: ca9f5fa95ffab41fb9a615ab714db018,
+  m_ScrollWheelAction: {fileID: 4502412055082496612, guid: d80d7c671c79a4663a165a0a38e5cb17,
     type: 3}
-  m_TrackedDevicePositionAction: {fileID: 4754684134866288074, guid: ca9f5fa95ffab41fb9a615ab714db018,
+  m_TrackedDevicePositionAction: {fileID: 4754684134866288074, guid: d80d7c671c79a4663a165a0a38e5cb17,
     type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: 1025543830046995696, guid: ca9f5fa95ffab41fb9a615ab714db018,
+  m_TrackedDeviceOrientationAction: {fileID: 1025543830046995696, guid: d80d7c671c79a4663a165a0a38e5cb17,
     type: 3}
-  m_TrackedDeviceSelectAction: {fileID: 2559092417903258184, guid: ca9f5fa95ffab41fb9a615ab714db018,
+  m_TrackedDeviceSelectAction: {fileID: 2559092417903258184, guid: d80d7c671c79a4663a165a0a38e5cb17,
     type: 3}
 --- !u!114 &1885387163
 MonoBehaviour:
@@ -1102,7 +1102,7 @@ MonoBehaviour:
   m_Script: {fileID: -619905303, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
+  m_FirstSelected: {fileID: 1939182812}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
 --- !u!4 &1885387164

--- a/Assets/Scenes/PlayerSelection.unity
+++ b/Assets/Scenes/PlayerSelection.unity
@@ -142,7 +142,7 @@ PrefabInstance:
     - target: {fileID: 7523088344687940633, guid: f31b797619fa44491a973671808b7827,
         type: 3}
       propertyPath: m_Name
-      value: PlayerSelection (1)
+      value: PlayerSelectionP2
       objectReference: {fileID: 0}
     - target: {fileID: 7523088344687940633, guid: f31b797619fa44491a973671808b7827,
         type: 3}
@@ -483,7 +483,7 @@ PrefabInstance:
     - target: {fileID: 7523088344687940633, guid: f31b797619fa44491a973671808b7827,
         type: 3}
       propertyPath: m_Name
-      value: PlayerSelection (2)
+      value: PlayerSelectionP3
       objectReference: {fileID: 0}
     - target: {fileID: 7523088344687940633, guid: f31b797619fa44491a973671808b7827,
         type: 3}
@@ -615,91 +615,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fdeb8bbe21140482192cd90d047d2755, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &1467666534
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1467666537}
-  - component: {fileID: 1467666536}
-  - component: {fileID: 1467666535}
-  m_Layer: 0
-  m_Name: EventSystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1467666535
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1467666534}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_RepeatDelay: 0.5
-  m_RepeatRate: 0.1
-  m_ActionsAsset: {fileID: -944628639613478452, guid: d80d7c671c79a4663a165a0a38e5cb17,
-    type: 3}
-  m_PointAction: {fileID: 1054132383583890850, guid: d80d7c671c79a4663a165a0a38e5cb17,
-    type: 3}
-  m_MoveAction: {fileID: 3710738434707379630, guid: d80d7c671c79a4663a165a0a38e5cb17,
-    type: 3}
-  m_SubmitAction: {fileID: 2064916234097673511, guid: d80d7c671c79a4663a165a0a38e5cb17,
-    type: 3}
-  m_CancelAction: {fileID: -1967631576421560919, guid: d80d7c671c79a4663a165a0a38e5cb17,
-    type: 3}
-  m_LeftClickAction: {fileID: 8056856818456041789, guid: d80d7c671c79a4663a165a0a38e5cb17,
-    type: 3}
-  m_MiddleClickAction: {fileID: 3279352641294131588, guid: d80d7c671c79a4663a165a0a38e5cb17,
-    type: 3}
-  m_RightClickAction: {fileID: 3837173908680883260, guid: d80d7c671c79a4663a165a0a38e5cb17,
-    type: 3}
-  m_ScrollWheelAction: {fileID: 4502412055082496612, guid: d80d7c671c79a4663a165a0a38e5cb17,
-    type: 3}
-  m_TrackedDevicePositionAction: {fileID: 4754684134866288074, guid: d80d7c671c79a4663a165a0a38e5cb17,
-    type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: 1025543830046995696, guid: d80d7c671c79a4663a165a0a38e5cb17,
-    type: 3}
-  m_TrackedDeviceSelectAction: {fileID: 2559092417903258184, guid: d80d7c671c79a4663a165a0a38e5cb17,
-    type: 3}
---- !u!114 &1467666536
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1467666534}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -619905303, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!4 &1467666537
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1467666534}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1490333848
 GameObject:
   m_ObjectHideFlags: 0
@@ -730,7 +645,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1490333850
 MonoBehaviour:
@@ -761,10 +676,10 @@ MonoBehaviour:
   m_JoinAction:
     m_UseReference: 0
     m_Action:
-      m_Name: 
+      m_Name: Action
       m_Type: 0
       m_ExpectedControlType: 
-      m_Id: 
+      m_Id: 2a1aa282-b586-45ad-b414-da0ac8f1d64b
       m_Processors: 
       m_Interactions: 
       m_SingletonActionBindings: []
@@ -1098,7 +1013,7 @@ PrefabInstance:
     - target: {fileID: 7523088344687940633, guid: f31b797619fa44491a973671808b7827,
         type: 3}
       propertyPath: m_Name
-      value: PlayerSelection (3)
+      value: PlayerSelectionP4
       objectReference: {fileID: 0}
     - target: {fileID: 7523088344687940633, guid: f31b797619fa44491a973671808b7827,
         type: 3}
@@ -1366,7 +1281,7 @@ PrefabInstance:
     - target: {fileID: 7523088344687940633, guid: f31b797619fa44491a973671808b7827,
         type: 3}
       propertyPath: m_Name
-      value: PlayerSelection
+      value: PlayerSelectionP1
       objectReference: {fileID: 0}
     - target: {fileID: 7523088344687940633, guid: f31b797619fa44491a973671808b7827,
         type: 3}

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 using UnityEngine.SceneManagement;
 using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.UI;
 
 public class PlayerManager : MonoBehaviour
 {
@@ -81,6 +83,7 @@ public class PlayerManager : MonoBehaviour
 
     private void OnPlayerJoined(PlayerInput player)
     {
+        // update mapping
         var devices = new InputDevice[player.devices.Count];
         for (int i = 0; i < player.devices.Count; i++)
         {
@@ -88,11 +91,15 @@ public class PlayerManager : MonoBehaviour
         }
         var mapping = new PlayerMapping(playerAddIdx, devices, null);
         mappings[playerAddIdx] = mapping;
-
+        // update UI
         var selection = playerSelections[playerAddIdx];
         selection.gameObject.SetActive(true);
         selection.SetTagText($"P{playerAddIdx + 1}");
         selection.SetControllerText(player.currentControlScheme);
+        // connect player to UI
+        var evtSystem = player.GetComponent<MultiplayerEventSystem>();
+        evtSystem.playerRoot = selection.gameObject;
+        evtSystem.firstSelectedGameObject = selection.GetComponentInChildren<Button>().gameObject;
 
         playerAddIdx += 1;
     }


### PR DESCRIPTION
gamepad can now control main menu, player selection screen, and end game screen

Note: mouse events on player selection screen won't work outside PC player's buttons due to `MultiplayerEventSystem.playerRoot` https://docs.unity3d.com/Packages/com.unity.inputsystem@1.0/api/UnityEngine.InputSystem.UI.MultiplayerEventSystem.html#UnityEngine_InputSystem_UI_MultiplayerEventSystem_playerRoot